### PR TITLE
#40: Support splitting incoming requests into multiple messages

### DIFF
--- a/etc/config.properties
+++ b/etc/config.properties
@@ -17,3 +17,5 @@ credentials.file=etc/credentials.json
 
 lookups.hostname.file=etc/hostname.json
 lookups.appname.file=etc/appname.json
+
+payload.splitRegex=\n

--- a/etc/config.properties
+++ b/etc/config.properties
@@ -19,3 +19,4 @@ lookups.hostname.file=etc/hostname.json
 lookups.appname.file=etc/appname.json
 
 payload.splitRegex=\n
+payload.splitEnabled=false

--- a/src/main/java/com/teragrep/lsh_01/Main.java
+++ b/src/main/java/com/teragrep/lsh_01/Main.java
@@ -36,12 +36,14 @@ public class Main {
         BasicAuthentication basicAuthentication = new BasicAuthenticationFactory().create();
         InternalEndpointUrlConfig internalEndpointUrlConfig = new InternalEndpointUrlConfig();
         LookupConfig lookupConfig = new LookupConfig();
+        PayloadConfig payloadConfig = new PayloadConfig();
         try {
             nettyConfig.validate();
             relpConfig.validate();
             securityConfig.validate();
             internalEndpointUrlConfig.validate();
             lookupConfig.validate();
+            payloadConfig.validate();
         }
         catch (IllegalArgumentException e) {
             LOGGER.error("Can't parse config properly: {}", e.getMessage());
@@ -51,12 +53,14 @@ public class Main {
         LOGGER.info("Got relp config: <[{}]>", relpConfig);
         LOGGER.info("Got internal endpoint config: <[{}]>", internalEndpointUrlConfig);
         LOGGER.info("Got lookup table config: <[{}]>", lookupConfig);
+        LOGGER.info("Got payload config: <[{}]>", payloadConfig);
         LOGGER.info("Authentication required: <[{}]>", securityConfig.authRequired);
         RelpConversion relpConversion = new RelpConversion(
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                lookupConfig
+                lookupConfig,
+                payloadConfig
         );
         try (
                 NettyHttpServer server = new NettyHttpServer(

--- a/src/main/java/com/teragrep/lsh_01/Payload.java
+++ b/src/main/java/com/teragrep/lsh_01/Payload.java
@@ -1,0 +1,73 @@
+/*
+  logstash-http-input to syslog bridge
+  Copyright 2024 Suomen Kanuuna Oy
+
+  Derivative Work of Elasticsearch
+  Copyright 2012-2015 Elasticsearch
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.teragrep.lsh_01;
+
+import com.teragrep.lsh_01.config.PayloadConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * A message from a log source
+ */
+final public class Payload {
+
+    private final static Logger LOGGER = LogManager.getLogger(Payload.class);
+    private final PayloadConfig payloadConfig;
+    private final String body;
+
+    public Payload(PayloadConfig payloadConfig, String body) {
+        this.payloadConfig = payloadConfig;
+        this.body = body;
+    }
+
+    /**
+     * Splits the payload into multiple payloads if there is a defined split regex in the body.
+     * @return list of Payloads
+     */
+    public List<Payload> split() {
+        ArrayList<Payload> payloads = new ArrayList<>();
+
+        try {
+            String[] messages = body.split(payloadConfig.splitRegex);
+
+            for (String message: messages) {
+                payloads.add(new Payload(payloadConfig, message));
+            }
+        } catch (PatternSyntaxException e) {
+            LOGGER.error("Invalid splitRegex in configuration: <{}>", payloadConfig.splitRegex);
+            payloads.add(this);
+        }
+
+        return payloads;
+    }
+
+    /**
+     * Takes the message from the payload.
+     * @return message body
+     */
+    public String take() {
+        return body;
+    }
+}

--- a/src/main/java/com/teragrep/lsh_01/Payload.java
+++ b/src/main/java/com/teragrep/lsh_01/Payload.java
@@ -44,10 +44,16 @@ final public class Payload {
 
     /**
      * Splits the payload into multiple payloads if there is a defined split regex in the body.
+     * Only works if the payload.splitEnabled is set to true.
      * @return list of Payloads
      */
     public List<Payload> split() {
         ArrayList<Payload> payloads = new ArrayList<>();
+
+        if (!payloadConfig.splitEnabled) {
+            payloads.add(this);
+            return payloads;
+        }
 
         try {
             String[] messages = body.split(payloadConfig.splitRegex);

--- a/src/main/java/com/teragrep/lsh_01/config/PayloadConfig.java
+++ b/src/main/java/com/teragrep/lsh_01/config/PayloadConfig.java
@@ -23,12 +23,14 @@ package com.teragrep.lsh_01.config;
 public class PayloadConfig implements Validateable {
 
     public final String splitRegex;
+    public final boolean splitEnabled;
 
     public PayloadConfig() {
         PropertiesReaderUtilityClass propertiesReader = new PropertiesReaderUtilityClass(
                 System.getProperty("properties.file", "etc/config.properties")
         );
         splitRegex = propertiesReader.getStringProperty("payload.splitRegex");
+        splitEnabled = propertiesReader.getBooleanProperty("payload.splitEnabled");
     }
 
     @Override
@@ -38,6 +40,6 @@ public class PayloadConfig implements Validateable {
 
     @Override
     public String toString() {
-        return "PayloadConfig{" + "splitRegex='" + splitRegex + '}';
+        return "PayloadConfig{" + "splitRegex=" + splitRegex + ", splitEnabled=" + splitEnabled + '}';
     }
 }

--- a/src/main/java/com/teragrep/lsh_01/config/PayloadConfig.java
+++ b/src/main/java/com/teragrep/lsh_01/config/PayloadConfig.java
@@ -1,0 +1,43 @@
+/*
+  logstash-http-input to syslog bridge
+  Copyright 2024 Suomen Kanuuna Oy
+
+  Derivative Work of Elasticsearch
+  Copyright 2012-2015 Elasticsearch
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.teragrep.lsh_01.config;
+
+public class PayloadConfig implements Validateable {
+
+    public final String splitRegex;
+
+    public PayloadConfig() {
+        PropertiesReaderUtilityClass propertiesReader = new PropertiesReaderUtilityClass(
+                System.getProperty("properties.file", "etc/config.properties")
+        );
+        splitRegex = propertiesReader.getStringProperty("payload.splitRegex");
+    }
+
+    @Override
+    public void validate() {
+
+    }
+
+    @Override
+    public String toString() {
+        return "PayloadConfig{" + "splitRegex='" + splitRegex + '}';
+    }
+}

--- a/src/test/java/CredentialsTest.java
+++ b/src/test/java/CredentialsTest.java
@@ -21,6 +21,7 @@ import com.teragrep.lsh_01.authentication.BasicAuthentication;
 import com.teragrep.lsh_01.RelpConversion;
 import com.teragrep.lsh_01.authentication.BasicAuthenticationFactory;
 import com.teragrep.lsh_01.config.LookupConfig;
+import com.teragrep.lsh_01.config.PayloadConfig;
 import com.teragrep.lsh_01.config.RelpConfig;
 import com.teragrep.lsh_01.config.SecurityConfig;
 import org.junit.jupiter.api.AfterEach;
@@ -56,7 +57,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertFalse(relpConversion.requiresToken());
     }
@@ -81,7 +83,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         // FirstUser:VeryFirstPassword
@@ -101,7 +104,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         // Test
@@ -121,7 +125,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         // UserWithColons:My:Password:Yay
@@ -139,7 +144,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         IllegalArgumentException e = Assertions
@@ -158,7 +164,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         IllegalArgumentException e = Assertions
@@ -180,7 +187,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         // SecondUser:WrongPassword -> Right user
@@ -202,7 +210,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         // :VeryFirstPassword -> Valid password, null username
@@ -224,7 +233,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         // FirstUser: -> Valid username, null password
@@ -244,7 +254,8 @@ public class CredentialsTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
         Assertions.assertTrue(relpConversion.requiresToken());
         IllegalArgumentException e = Assertions

--- a/src/test/java/LookupTest.java
+++ b/src/test/java/LookupTest.java
@@ -23,6 +23,7 @@ import com.teragrep.lsh_01.authentication.BasicAuthentication;
 import com.teragrep.lsh_01.authentication.BasicAuthenticationFactory;
 import com.teragrep.lsh_01.authentication.Subject;
 import com.teragrep.lsh_01.config.LookupConfig;
+import com.teragrep.lsh_01.config.PayloadConfig;
 import com.teragrep.lsh_01.config.RelpConfig;
 import com.teragrep.lsh_01.config.SecurityConfig;
 import com.teragrep.lsh_01.lookup.LookupTableFactory;
@@ -63,7 +64,8 @@ public class LookupTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
 
         // FirstUser:VeryFirstPassword!
@@ -85,7 +87,8 @@ public class LookupTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
 
         // FirstUser:VeryFirstPassword!
@@ -109,7 +112,8 @@ public class LookupTest {
                 relpConfig,
                 securityConfig,
                 basicAuthentication,
-                new LookupConfig()
+                new LookupConfig(),
+                new PayloadConfig()
         );
 
         // MissingHostname:MyHostnameIsMissing

--- a/src/test/java/PayloadTest.java
+++ b/src/test/java/PayloadTest.java
@@ -1,0 +1,80 @@
+/*
+  logstash-http-input to syslog bridge
+  Copyright 2024 Suomen Kanuuna Oy
+
+  Derivative Work of Elasticsearch
+  Copyright 2012-2015 Elasticsearch
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import com.teragrep.lsh_01.Payload;
+import com.teragrep.lsh_01.config.PayloadConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class PayloadTest {
+
+    @BeforeEach
+    public void addProperties() {
+        System.setProperty("payload.splitRegex", "\\n");
+    }
+
+    @AfterEach
+    public void cleanProperties() {
+        System.clearProperty("payload.splitRegex");
+    }
+
+    @Test
+    public void testDefaultSplitRegex() {
+        String body = "foo\nbar\nfoobar";
+        PayloadConfig payloadConfig = new PayloadConfig();
+        Payload payload = new Payload(payloadConfig, body);
+        List<Payload> payloads = payload.split();
+
+        Assertions.assertEquals(3, payloads.size());
+        Assertions.assertEquals("foo", payloads.get(0).take());
+        Assertions.assertEquals("bar", payloads.get(1).take());
+        Assertions.assertEquals("foobar", payloads.get(2).take());
+    }
+
+    @Test
+    public void testCustomSplitRegex() {
+        System.setProperty("payload.splitRegex", ",");
+
+        String body = "foo,bar,foobar";
+        PayloadConfig payloadConfig = new PayloadConfig();
+        Payload payload = new Payload(payloadConfig, body);
+        List<Payload> payloads = payload.split();
+
+        Assertions.assertEquals(3, payloads.size());
+        Assertions.assertEquals("foo", payloads.get(0).take());
+        Assertions.assertEquals("bar", payloads.get(1).take());
+        Assertions.assertEquals("foobar", payloads.get(2).take());
+    }
+
+    @Test
+    public void testNoSplittingRequired() {
+        String body = "foobar";
+        PayloadConfig payloadConfig = new PayloadConfig();
+        Payload payload = new Payload(payloadConfig, body);
+        List<Payload> payloads = payload.split();
+
+        Assertions.assertEquals(1, payloads.size());
+        Assertions.assertEquals("foobar", payloads.get(0).take());
+    }
+}

--- a/src/test/java/PayloadTest.java
+++ b/src/test/java/PayloadTest.java
@@ -32,15 +32,19 @@ public class PayloadTest {
     @BeforeEach
     public void addProperties() {
         System.setProperty("payload.splitRegex", "\\n");
+        System.setProperty("payload.splitEnabled", "false");
     }
 
     @AfterEach
     public void cleanProperties() {
         System.clearProperty("payload.splitRegex");
+        System.clearProperty("payload.splitEnabled");
     }
 
     @Test
     public void testDefaultSplitRegex() {
+        System.setProperty("payload.splitEnabled", "true");
+
         String body = "foo\nbar\nfoobar";
         PayloadConfig payloadConfig = new PayloadConfig();
         Payload payload = new Payload(payloadConfig, body);
@@ -55,6 +59,7 @@ public class PayloadTest {
     @Test
     public void testCustomSplitRegex() {
         System.setProperty("payload.splitRegex", ",");
+        System.setProperty("payload.splitEnabled", "true");
 
         String body = "foo,bar,foobar";
         PayloadConfig payloadConfig = new PayloadConfig();
@@ -69,6 +74,8 @@ public class PayloadTest {
 
     @Test
     public void testNoSplittingRequired() {
+        System.setProperty("payload.splitEnabled", "true");
+
         String body = "foobar";
         PayloadConfig payloadConfig = new PayloadConfig();
         Payload payload = new Payload(payloadConfig, body);
@@ -76,5 +83,17 @@ public class PayloadTest {
 
         Assertions.assertEquals(1, payloads.size());
         Assertions.assertEquals("foobar", payloads.get(0).take());
+    }
+
+    @Test
+    public void testSplitDisabled() {
+        // disabled by default
+        String body = "foo\nbar\nfoobar";
+        PayloadConfig payloadConfig = new PayloadConfig();
+        Payload payload = new Payload(payloadConfig, body);
+        List<Payload> payloads = payload.split();
+
+        Assertions.assertEquals(1, payloads.size());
+        Assertions.assertEquals(body, payloads.get(0).take());
     }
 }


### PR DESCRIPTION
New messages are split into multiple messages if the split regex defined in config matches parts of the message body.

The split regex is a newline character (\n) by default.