### PR TITLE
Fix #50: Add check for null header values in incoming request

### DIFF
--- a/src/main/java/com/teragrep/lsh_01/RelpConversion.java
+++ b/src/main/java/com/teragrep/lsh_01/RelpConversion.java
@@ -121,7 +121,11 @@ public class RelpConversion implements IMessageHandler {
 
         SDElement headerSDElement = new SDElement("lsh_01_headers@48577");
         for (Map.Entry<String, String> header : headers.entrySet()) {
-            headerSDElement.addSDParam(new SDParam(header.getKey(), header.getValue()));
+            String headerValue = header.getValue();
+            if (headerValue == null) {
+                headerValue = "";
+            }
+            headerSDElement.addSDParam(new SDParam(header.getKey(), headerValue));
         }
         SDElement sdElement = new SDElement("lsh_01@48577");
         sdElement.addSDParam("subject", subject);


### PR DESCRIPTION
Checks for null headers in incoming request. #50 was caused by Accept header being null in the test plan.

Changes null values to be empty Strings, is this okay?

The fix could also be implemented in rlo_14 instead.

Tested with the same test plan with JMeter, no unit test yet as end to end testing is not implemented yet (see #53). 