### PR TITLE
Fix tests failing due to default relp.port in privileged range

### DIFF
--- a/src/test/java/EndToEndTest.java
+++ b/src/test/java/EndToEndTest.java
@@ -45,6 +45,7 @@ public class EndToEndTest {
         System.setProperty("payload.splitEnabled", "true");
         System.setProperty("security.authRequired", "false");
         System.setProperty("relp.reconnectInterval", "1000");
+        System.setProperty("relp.port", "1601");
 
         // Start listening to HTTP-requests
         Thread program = new Thread(() -> Main.main(new String[] {}));
@@ -68,6 +69,7 @@ public class EndToEndTest {
         System.clearProperty("payload.splitEnabled");
         System.clearProperty("security.authRequired");
         System.clearProperty("relp.reconnectInterval");
+        System.clearProperty("relp.port");
         this.relpServer.tearDown();
     }
 

--- a/src/test/java/RebindTest.java
+++ b/src/test/java/RebindTest.java
@@ -37,6 +37,8 @@ public class RebindTest {
 
     @BeforeAll
     void setUp() {
+        System.setProperty("relp.port", "1601");
+
         this.relpServer = new RelpServer();
         this.relpServer.setUpCounting();
     }
@@ -58,6 +60,7 @@ public class RebindTest {
         System.clearProperty("relp.rebindEnabled");
         System.clearProperty("relp.rebindRequestAmount");
         System.clearProperty("relp.reconnectInterval");
+        System.clearProperty("relp.port");
         this.relpServer.tearDown();
     }
 


### PR DESCRIPTION
Changed port to be 1601 in tests that use a RELP server.