### PR TITLE
Fix #69: Coverity defects

### DIFF
--- a/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
+++ b/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
@@ -32,7 +32,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
@@ -63,20 +62,10 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpReque
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) {
-        final String remoteAddress;
-        try {
-            remoteAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().getHostAddress();
-        }
-        catch (NullPointerException e) {
-            LOGGER.error("Couldn't get the remote address, returning.");
-            return;
-        }
-
         msg.retain();
         final MessageProcessor messageProcessor = new MessageProcessor(
                 ctx,
                 msg,
-                remoteAddress,
                 messageHandler,
                 responseStatus,
                 internalEndpointUrlConfig

--- a/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
+++ b/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
@@ -63,12 +63,15 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpReque
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) {
-        if (!ctx.channel().isActive()) {
-            LOGGER.error("The channel bound to the ChannelHandlerContext is not connected, can't handle the message.");
+        final String remoteAddress;
+        try {
+            remoteAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().getHostAddress();
+        }
+        catch (NullPointerException e) {
+            LOGGER.error("Couldn't get the remote address, returning.");
             return;
         }
 
-        final String remoteAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().getHostAddress();
         msg.retain();
         final MessageProcessor messageProcessor = new MessageProcessor(
                 ctx,

--- a/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
+++ b/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
@@ -63,7 +63,7 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpReque
     @Override
     public void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) {
         if (!ctx.channel().isActive()) {
-            LOGGER.error("The channel bound to ChannelHandlerContext is not connected, can't handle the message.");
+            LOGGER.error("The channel bound to the ChannelHandlerContext is not connected, can't handle the message.");
             return;
         }
 

--- a/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
+++ b/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
@@ -29,6 +29,8 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -39,6 +41,7 @@ import static io.netty.buffer.Unpooled.copiedBuffer;
  * Created by joaoduarte on 11/10/2017.
  */
 public class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private final static Logger LOGGER = LogManager.getLogger(HttpServerHandler.class);
 
     private final IMessageHandler messageHandler;
     private final ThreadPoolExecutor executorGroup;
@@ -59,6 +62,11 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpReque
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) {
+        if (!ctx.channel().isActive()) {
+            LOGGER.error("The channel bound to ChannelHandlerContext is not connected, can't handle the message.");
+            return;
+        }
+
         final String remoteAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().getHostAddress();
         msg.retain();
         final MessageProcessor messageProcessor = new MessageProcessor(

--- a/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
+++ b/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
@@ -41,6 +41,7 @@ import static io.netty.buffer.Unpooled.copiedBuffer;
  * Created by joaoduarte on 11/10/2017.
  */
 public class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+
     private final static Logger LOGGER = LogManager.getLogger(HttpServerHandler.class);
 
     private final IMessageHandler messageHandler;

--- a/src/main/java/com/teragrep/lsh_01/IMessageHandler.java
+++ b/src/main/java/com/teragrep/lsh_01/IMessageHandler.java
@@ -31,11 +31,10 @@ public interface IMessageHandler {
     /**
      * This is triggered on every new message parsed by the http handler and should be executed in the ruby world.
      *
-     * @param remoteAddress
      * @param headers
      * @param body
      */
-    boolean onNewMessage(String remoteAddress, Subject subject, Map<String, String> headers, String body);
+    boolean onNewMessage(Subject subject, Map<String, String> headers, String body);
 
     /**
      * @param token

--- a/src/main/java/com/teragrep/lsh_01/MessageProcessor.java
+++ b/src/main/java/com/teragrep/lsh_01/MessageProcessor.java
@@ -45,7 +45,6 @@ public class MessageProcessor implements RejectableRunnable {
 
     private final ChannelHandlerContext ctx;
     private final FullHttpRequest req;
-    private final String remoteAddress;
     private final IMessageHandler messageHandler;
     private final HttpResponseStatus responseStatus;
     private final InternalEndpointUrlConfig internalEndpointUrlConfig;
@@ -56,14 +55,12 @@ public class MessageProcessor implements RejectableRunnable {
     MessageProcessor(
             ChannelHandlerContext ctx,
             FullHttpRequest req,
-            String remoteAddress,
             IMessageHandler messageHandler,
             HttpResponseStatus responseStatus,
             InternalEndpointUrlConfig internalEndpointUrlConfig
     ) {
         this.ctx = ctx;
         this.req = req;
-        this.remoteAddress = remoteAddress;
         this.messageHandler = messageHandler;
         this.responseStatus = responseStatus;
         this.internalEndpointUrlConfig = internalEndpointUrlConfig;
@@ -137,7 +134,7 @@ public class MessageProcessor implements RejectableRunnable {
     private FullHttpResponse processMessage(Subject subject) {
         final Map<String, String> formattedHeaders = formatHeaders(req.headers());
         final String body = req.content().toString(UTF8_CHARSET);
-        if (messageHandler.onNewMessage(remoteAddress, subject, formattedHeaders, body)) {
+        if (messageHandler.onNewMessage(subject, formattedHeaders, body)) {
             return generateResponse(messageHandler.responseHeaders());
         }
         else {

--- a/src/main/java/com/teragrep/lsh_01/RelpConversion.java
+++ b/src/main/java/com/teragrep/lsh_01/RelpConversion.java
@@ -64,7 +64,7 @@ public class RelpConversion implements IMessageHandler {
         this.payloadConfig = payloadConfig;
     }
 
-    public boolean onNewMessage(String remoteAddress, Subject subject, Map<String, String> headers, String body) {
+    public boolean onNewMessage(Subject subject, Map<String, String> headers, String body) {
         try {
             if (payloadConfig.splitEnabled) {
                 Pattern splitPattern = Pattern.compile(payloadConfig.splitRegex);

--- a/src/main/java/com/teragrep/lsh_01/config/PayloadConfig.java
+++ b/src/main/java/com/teragrep/lsh_01/config/PayloadConfig.java
@@ -39,7 +39,7 @@ public class PayloadConfig implements Validateable {
     public void validate() {
         if (splitEnabled) {
             try {
-                Pattern splitPattern = Pattern.compile(splitRegex);
+                Pattern.compile(splitRegex);
             }
             catch (PatternSyntaxException e) {
                 throw new IllegalArgumentException(


### PR DESCRIPTION
Fixed Coverity defects 460538 and 452917.

The first (460538) was a simple useless variable assignment in PayloadConfig.

The second (452917) was a possible NPE in HttpServerHandler. `ChannelHandlerContext.remoteAddress()` might return null if the channel is not connected. I noticed that there is a check for this in the class `isActive()` so I used that and logged the error and returned. This might not be the best way to deal with the situation, maybe an error should be thrown instead? Furthermore, Coverity might not see that the NPE is dealt with this fix so it needs to be solved manually from Coverity after merging.

In #69, fixing was specifically asked for 461131. This was a possible NullPointerException in `RelpConversion`'s `sendMessage()`, but the function call is already surrounded by a try catch as per #7, so in my opinion a null check for this is a bit overkill and clutters the code more. There is also no threat of a null happening there yet with the current Supplier (`RelpConnectionFactory`), but this might of course change in the future.

Went over the rest of the defects in Coverity as well, and I don't think they are necessary to "fix", I think they are false positives mostly.