### PR TITLE
Fix #67: solved a bug where reconnect time would be waited even for succesful connections

### DIFF
--- a/src/main/java/com/teragrep/lsh_01/pool/ManagedRelpConnection.java
+++ b/src/main/java/com/teragrep/lsh_01/pool/ManagedRelpConnection.java
@@ -57,7 +57,7 @@ public class ManagedRelpConnection implements IManagedRelpConnection {
                     Thread.sleep(relpConnection.relpConfig().relpReconnectInterval);
                 }
                 catch (InterruptedException exception) {
-                    LOGGER.error("Reconnect timer interrupted, reconnecting now");
+                    LOGGER.error("Reconnection timer interrupted, reconnecting now");
                 }
             }
         }

--- a/src/main/java/com/teragrep/lsh_01/pool/ManagedRelpConnection.java
+++ b/src/main/java/com/teragrep/lsh_01/pool/ManagedRelpConnection.java
@@ -52,13 +52,13 @@ public class ManagedRelpConnection implements IManagedRelpConnection {
                                 relpConnection.relpConfig().relpTarget, relpConnection.relpConfig().relpPort,
                                 e.getMessage()
                         );
-            }
 
-            try {
-                Thread.sleep(relpConnection.relpConfig().relpReconnectInterval);
-            }
-            catch (InterruptedException e) {
-                LOGGER.error("Reconnect timer interrupted, reconnecting now");
+                try {
+                    Thread.sleep(relpConnection.relpConfig().relpReconnectInterval);
+                }
+                catch (InterruptedException exception) {
+                    LOGGER.error("Reconnect timer interrupted, reconnecting now");
+                }
             }
         }
     }

--- a/src/test/java/EndToEndTest.java
+++ b/src/test/java/EndToEndTest.java
@@ -44,7 +44,6 @@ public class EndToEndTest {
     void setUp() throws InterruptedException {
         System.setProperty("payload.splitEnabled", "true");
         System.setProperty("security.authRequired", "false");
-        System.setProperty("relp.reconnectInterval", "1000");
         System.setProperty("relp.port", "1601");
 
         // Start listening to HTTP-requests
@@ -68,7 +67,6 @@ public class EndToEndTest {
     void tearDown() {
         System.clearProperty("payload.splitEnabled");
         System.clearProperty("security.authRequired");
-        System.clearProperty("relp.reconnectInterval");
         System.clearProperty("relp.port");
         this.relpServer.tearDown();
     }

--- a/src/test/java/RebindTest.java
+++ b/src/test/java/RebindTest.java
@@ -47,7 +47,6 @@ public class RebindTest {
     void setProperties() {
         System.setProperty("relp.rebindEnabled", "true");
         System.setProperty("relp.rebindRequestAmount", "5");
-        System.setProperty("relp.reconnectInterval", "500");
     }
 
     @AfterEach
@@ -59,7 +58,6 @@ public class RebindTest {
     void tearDown() {
         System.clearProperty("relp.rebindEnabled");
         System.clearProperty("relp.rebindRequestAmount");
-        System.clearProperty("relp.reconnectInterval");
         System.clearProperty("relp.port");
         this.relpServer.tearDown();
     }


### PR DESCRIPTION
Solves issue #67.

There was a bug introduced in #66 where the `Thread.sleep()` meant to be called for a failed attempt at connecting would also be called once for a successful attempt.

Moved the sleep function call inside the catch block where the failed connection is handled.