### PR TITLE
Fix more coverity defects

### DIFF
--- a/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
+++ b/src/main/java/com/teragrep/lsh_01/HttpServerHandler.java
@@ -29,9 +29,8 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
@@ -40,8 +39,6 @@ import static io.netty.buffer.Unpooled.copiedBuffer;
  * Created by joaoduarte on 11/10/2017.
  */
 public class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
-
-    private final static Logger LOGGER = LogManager.getLogger(HttpServerHandler.class);
 
     private final IMessageHandler messageHandler;
     private final ThreadPoolExecutor executorGroup;
@@ -74,8 +71,8 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpReque
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        final ByteBuf content = copiedBuffer(cause.getMessage().getBytes());
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        final ByteBuf content = copiedBuffer(cause.getMessage().getBytes(StandardCharsets.UTF_8));
         final HttpResponseStatus responseStatus;
 
         if (cause instanceof DecompressionException) {

--- a/src/main/java/com/teragrep/lsh_01/MessageProcessor.java
+++ b/src/main/java/com/teragrep/lsh_01/MessageProcessor.java
@@ -164,8 +164,8 @@ public class MessageProcessor implements RejectableRunnable {
 
         final FullHttpResponse response = new DefaultFullHttpResponse(req.protocolVersion(), responseStatus);
         final DefaultHttpHeaders headers = new DefaultHttpHeaders();
-        for (String key : stringHeaders.keySet()) {
-            headers.set(key, stringHeaders.get(key));
+        for (Map.Entry<String, String> entry : stringHeaders.entrySet()) {
+            headers.set(entry.getKey(), entry.getValue());
         }
         response.headers().set(headers);
 

--- a/src/main/java/com/teragrep/lsh_01/NettyHttpServer.java
+++ b/src/main/java/com/teragrep/lsh_01/NettyHttpServer.java
@@ -46,12 +46,9 @@ public class NettyHttpServer implements Runnable, Closeable {
     private final ServerBootstrap serverBootstrap;
     private final String host;
     private final int port;
-    private final int connectionBacklog = 128;
 
     private final EventLoopGroup processorGroup;
     private final ThreadPoolExecutor executorGroup;
-    private final HttpResponseStatus responseStatus;
-    private final InternalEndpointUrlConfig internalEndpointUrlConfig;
 
     public NettyHttpServer(
             NettyConfig nettyConfig,
@@ -62,8 +59,6 @@ public class NettyHttpServer implements Runnable, Closeable {
     ) {
         this.host = nettyConfig.listenAddress;
         this.port = nettyConfig.listenPort;
-        this.internalEndpointUrlConfig = internalEndpointUrlConfig;
-        this.responseStatus = HttpResponseStatus.valueOf(responseCode);
         processorGroup = new NioEventLoopGroup(nettyConfig.threads, daemonThreadFactory("http-input-processor"));
 
         executorGroup = new ThreadPoolExecutor(
@@ -80,7 +75,7 @@ public class NettyHttpServer implements Runnable, Closeable {
                 messageHandler,
                 executorGroup,
                 nettyConfig.maxContentLength,
-                responseStatus,
+                HttpResponseStatus.valueOf(responseCode),
                 internalEndpointUrlConfig
         );
 
@@ -88,6 +83,7 @@ public class NettyHttpServer implements Runnable, Closeable {
             httpInitializer.enableSSL(sslHandlerProvider);
         }
 
+        int connectionBacklog = 128;
         serverBootstrap = new ServerBootstrap()
                 .group(processorGroup)
                 .channel(NioServerSocketChannel.class)

--- a/src/main/java/com/teragrep/lsh_01/authentication/BasicAuthentication.java
+++ b/src/main/java/com/teragrep/lsh_01/authentication/BasicAuthentication.java
@@ -23,6 +23,7 @@ import com.teragrep.jai_02.CredentialLookup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public class BasicAuthentication {
@@ -49,7 +50,10 @@ public class BasicAuthentication {
         if (!token.startsWith("Basic ")) {
             throw new IllegalArgumentException("Got invalid token, doesn't start with Basic");
         }
-        String tokenString = new String(decoder.decode(token.substring("Basic".length()).trim()));
+        String tokenString = new String(
+                decoder.decode(token.substring("Basic".length()).trim()),
+                StandardCharsets.UTF_8
+        );
         if (!tokenString.contains(":")) {
             throw new IllegalArgumentException("Got invalid token, doesn't include colon");
         }

--- a/src/main/java/com/teragrep/lsh_01/authentication/BasicAuthenticationFactory.java
+++ b/src/main/java/com/teragrep/lsh_01/authentication/BasicAuthenticationFactory.java
@@ -22,8 +22,9 @@ package com.teragrep.lsh_01.authentication;
 import com.teragrep.jai_02.CredentialLookup;
 
 import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class BasicAuthenticationFactory {
 
@@ -31,9 +32,9 @@ public class BasicAuthenticationFactory {
         BufferedReader br;
         String credentialsFile = System.getProperty("credentials.file", "etc/credentials.json");
         try {
-            br = new BufferedReader(new FileReader(credentialsFile));
+            br = new BufferedReader(new FileReader(credentialsFile, StandardCharsets.UTF_8));
         }
-        catch (FileNotFoundException e) {
+        catch (IOException e) {
             throw new IllegalArgumentException(
                     "Can't find credentials.json from path <[" + credentialsFile + "]>: ",
                     e

--- a/src/main/java/com/teragrep/lsh_01/config/PropertiesReaderUtilityClass.java
+++ b/src/main/java/com/teragrep/lsh_01/config/PropertiesReaderUtilityClass.java
@@ -26,18 +26,23 @@ import java.util.Properties;
 
 public class PropertiesReaderUtilityClass {
 
+    private final String file;
     private final Properties properties = new Properties();
 
     public PropertiesReaderUtilityClass(String file) {
-        try (InputStream input = new FileInputStream(file)) {
-            properties.load(input);
-        }
-        catch (IOException ex) {
-            throw new IllegalArgumentException("Can't find properties file: ", ex);
-        }
+        this.file = file;
     }
 
     public String getStringProperty(String key) throws IllegalArgumentException {
+        if (properties.isEmpty()) { // read from file just once
+            try (InputStream input = new FileInputStream(file)) {
+                properties.load(input);
+            }
+            catch (IOException ex) {
+                throw new IllegalArgumentException("Can't find properties file: " + file, ex);
+            }
+        }
+
         String property = System.getProperty(key, properties.getProperty(key));
         if (property == null) {
             throw new IllegalArgumentException("Missing property: " + key);

--- a/src/main/java/com/teragrep/lsh_01/lookup/LookupTableFactory.java
+++ b/src/main/java/com/teragrep/lsh_01/lookup/LookupTableFactory.java
@@ -22,17 +22,18 @@ package com.teragrep.lsh_01.lookup;
 import com.teragrep.jlt_01.StringLookupTable;
 
 import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class LookupTableFactory {
 
     public StringLookupTable create(String path) {
         BufferedReader bufferedReader;
         try {
-            bufferedReader = new BufferedReader(new FileReader(path));
+            bufferedReader = new BufferedReader(new FileReader(path, StandardCharsets.UTF_8));
         }
-        catch (FileNotFoundException e) {
+        catch (IOException e) {
             throw new IllegalArgumentException("Can't find lookup table from path <[" + path + "]>: ", e);
         }
         return new StringLookupTable(bufferedReader);

--- a/src/test/java/ConfigTest.java
+++ b/src/test/java/ConfigTest.java
@@ -1,0 +1,45 @@
+/*
+  logstash-http-input to syslog bridge
+  Copyright 2024 Suomen Kanuuna Oy
+
+  Derivative Work of Elasticsearch
+  Copyright 2012-2015 Elasticsearch
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+import com.teragrep.lsh_01.config.PropertiesReaderUtilityClass;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigTest {
+
+    @Test
+    public void testNonexistentProperties() {
+        String emptyProps = "etc/nonexistent.properties";
+        PropertiesReaderUtilityClass propReader = new PropertiesReaderUtilityClass(emptyProps);
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> propReader.getStringProperty("payload.splitEnabled")
+        );
+        assertEquals("Can't find properties file: " + emptyProps, e.getMessage());
+    }
+
+    @Test
+    public void testProperties() {
+        String props = "etc/config.properties";
+        PropertiesReaderUtilityClass propReader = new PropertiesReaderUtilityClass(props);
+
+        assertDoesNotThrow(() -> propReader.getStringProperty("payload.splitEnabled"));
+    }
+}


### PR DESCRIPTION
Related to #69.

Refactored the code to fix defects reported by Coverity. The list of defects below doesn't tell much if there is no access to Coverity, but the list is there just to give context on what needed fixing. The PR is still merely about refactoring the code to be more secure and clean.

Coverity defects that should be solved by this:
467201 CT: Constructor throws
456623 Dm: Dubious method used
456622 Dm: Dubious method used
456284 Dm: Dubious method used
452921 SS: Unread field should be static (not actually changing to static, but changing it to a local variable)
452920 WMI: Inefficient Map Iterator
452918 Dm: Dubious method used

Two defects are not solved, because I think solving them would introduce code that is not in the spirit of Elegant Objects or otherwise weird:
- 467200 PI: Do not reuse public identifiers from Java Standard Library  (This one suggests not naming the Main class Main) 
- 461131 Dereference null return value  (This one suggests adding a null check to a return value from an object that is built by us, EO would say not to worry about nulls, our own code isn't supposed to return null)

NOTE:
The PR includes ConfigTests for the reason that I had to refactor the Exception throwing out of the constructor. I wanted to make sure I didn't break it in the process.