### PR TITLE
issue-#86 Metrics not printing on log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,17 @@
       <artifactId>jetty-servlet</artifactId>
       <version>10.0.15</version>
     </dependency>
+    <!-- slf4j -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>2.25.2</version>
+    </dependency>
     <!-- log4j -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Fix for issue #86 

Adds slf4j-api and log4j-slf4j2-impl to dependencies, so that metrics can be printed on log